### PR TITLE
Add Composum Nodes Toolsuite: JCR Browser, User amnager, Sling Package Manager and so forth

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ This is more of a short cut for people who don't want to navigate through the AE
 * [AEM Tooling Plugin for Intellij IDEA](https://github.com/headwirecom/aem-ide-tooling-4-intellij)
 * [NEBA](https://github.com/unic/neba) - integration of Spring Framework into Apache Sling
 * [WebSight](https://github.com/DS-WebSight) - Set of AEM/Sling Admin Tools (User Manager, Package Manager, Groovy Console and Resource Browser)
+* [Composum Nodes](https://github.com/ist-dresden/composum-nodes) - various AEM/Sling Admin Tools (Resource Browser, User Manager, Sling Package Manager, Groovy Console etc.)
 
 
 ----------------------------------------


### PR DESCRIPTION
Hi!

Thanks for that wonderful resource list!

I'd like to suggest to add the Composum Nodes browser, since that's a versatile tool suite that works on most AEM versions in use (incl. AEMaaCS), provides many tools: JCR Repository Browser, User Manager, Sling Package manager (if running on raw Apache Sling - it's included into the Sling Starter), Log viewer, Sling Ca Config Editor and various other small tools. On AEMaaCS you also get to use some of the old important tools like "recent requests" that are unavailable there, since the Felix console is gone / hidden.

BTW: I'm not sure about the line above:
* [WebSight](https://github.com/DS-WebSight) - Set of AEM/Sling Admin Tools (User Manager, Package Manager, Groovy Console and Resource Browser)
That link is broken and I wasn't able to find it on the web, not sure what happened with it.

Thanks a lot!
Hans-Peter